### PR TITLE
Casey

### DIFF
--- a/src/components/Board/Board.js
+++ b/src/components/Board/Board.js
@@ -3,7 +3,7 @@ import './Board.css';
 
 import { useState } from 'react';
 
-let board = [
+let boardInit = [
   ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight', 'rook'],
   ['pawn', 'pawn', 'pawn', 'pawn', 'pawn', 'pawn', 'pawn', 'pawn'],
   [null, null, null, null, null, null, null, null],
@@ -43,9 +43,18 @@ const Board = () => {
   return (
     <div>
       <div className='board-cont'>
-        {board.map((row) => {
-          return row.map((col) => {
-            return <div className='board-sqr'>{col}</div>;
+        {boardInit.map((row, x) => {
+          return row.map((col, y) => {
+            const id = `[${x},${y}]`;
+            return (
+              <div
+                id={id}
+                className='board-sqr'
+                onClick={() => console.log(id)}
+              >
+                {col}
+              </div>
+            );
           });
         })}
       </div>

--- a/src/pieces/Pawn.js
+++ b/src/pieces/Pawn.js
@@ -7,10 +7,19 @@ export default class Pawn extends Piece {
   }
 
   movementSquares() {
-    let moves = [
-      { row: this.row + 1, col: this.col },
-      !this.hasMoved && { row: this.row + 2, col: this.col },
-    ];
+    //Black pieces will only be able to move down rows while white can only move up
+    let moves =
+      //Black logic
+      this.color === 'black'
+        ? [
+            { row: this.row + 1, col: this.col },
+            !this.hasMoved && { row: this.row + 2, col: this.col },
+          ]
+        : //White logic
+          [
+            { row: this.row - 1, col: this.col },
+            !this.hasMoved && { row: this.row + 2, col: this.col },
+          ];
 
     moves.filter();
 
@@ -18,11 +27,18 @@ export default class Pawn extends Piece {
   }
 
   attackSquares() {
-    let moves = [
-      { row: this.row + 1, col: this.col + 1 },
-      { row: this.row + 1, col: this.col - 1 },
-    ];
-
+    let moves =
+      //Black logic
+      this.color === 'black'
+        ? [
+            { row: this.row + 1, col: this.col + 1 },
+            { row: this.row + 1, col: this.col - 1 },
+          ]
+        : //White logic
+          [
+            { row: this.row - 1, col: this.col + 1 },
+            { row: this.row - 1, col: this.col - 1 },
+          ];
     moves.filter();
 
     return moves;


### PR DESCRIPTION
Added logic under the pawn class that accounts for movements for both black and white pawns. Since they start on opposite ends of the board and can only go one direction, they are the only piece that will have movement and attack logic specific to their color. White pieces move up the board (which is down relative to the 2d array) and black pieces move down the board (which confusingly enough is up relative to the 2d array). 

In the board.js file, I added the index param for both the col and row when constructing the board. This makes is easier to access each square's X and Y coordinates to create a unique id that will be used for determining potential moves for the pieces.  